### PR TITLE
v1.1.0 features & fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,44 @@ const service = container.get("service");
 4. `.build()` finalizes the container.
 5. `.get("service")` returns the fully constructed *Service* with *Gateway* automatically injected.
 
+## Documentation
+- [Introduction](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/00-Introduction.md)
+- [Philosophy](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/01-Philosophy.md)
+- [Installation](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/03-Installation.md)
+- [Getting Started](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/04-Getting-Started.md)
+- **Basics**
+  - Container Configuration
+    - [Container Builder](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/01-Container-Builder.md)
+    - [About TypeMap](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/02-Type-Map.md)
+    - [Instance Binding](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/03-Instance-Binding.md)
+    - [Factory Binding](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/04-Factory-Binding.md)
+    - [Safe Factory Binding](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/05-Safe-Factory-Binding.md)
+    - [Class Factory](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/06-Class-Factory.md)
+    - [Named Binding](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/07-Named-Binding.md)
+    - [Binding Conflicts](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/08-Bindings-Conflict.md)
+    - [Multiple Binding](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/09-Multi-Bindings.md)
+    - [Lifecycles](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/10-Lifecycles.md)
+    - [Aliases](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/11-Aliases.md)
+    - [Container Build](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/01-Container-Configuration/12-Container-Build.md)
+  - Modules
+    - [Static Modules](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/02-Modules/01-Static-Modules.md)
+    - [Module Dependencies](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/02-Modules/02-Module-Dependencies.md)
+  - Resolving Instances
+    - [Type Enumeration](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/03-Resolving-Instances/01-Types-Enumeration.md)
+    - [Get Instance of Type](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/03-Resolving-Instances/02-Get-Instance-Of-Type.md)
+    - [Getting optional instances](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/03-Resolving-Instances/03-Get-Optional-Instance.md)
+    - [Getting all instances of a type](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/03-Resolving-Instances/04-Get-All-Instances-Of-Type.md)
+    - [Provider Functions](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/03-Resolving-Instances/05-Get-Provider-Function.md)
+    - [Phantom Instance](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/05-Basics/03-Resolving-Instances/06-Get-Phantom-Instance.md)
+- **Advanced**
+  - Container Builder
+    - [Container Builder Default Options](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/06-Advanced/01-Container-Builder/01-Default-Options.md)
+    - [Enforcing Type Bindings](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/06-Advanced/01-Container-Builder/02-Enforcing-Type-Bindings.md)
+    - [Injecting Dependencies into Existing Services](https://github.com/SpireX64/spirex-di/blob/main/docs/docs/06-Advanced/01-Container-Builder/03-Injecting-Into-Existing-Instances.md)
+
+_(Work In Progress)_
+
+
 ## Integrations & Extensions
 Container is designed to be fully extensible and works seamlessly with additional packages to enhance functionality:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 [![Codecov](https://img.shields.io/codecov/c/github/spirex64/spirex-di?token=VXQZK5WDSY&flag=di&style=for-the-badge)](https://codecov.io/github/SpireX64/spirex-di)
 
 
-`@spirex/di` is a **powerful**, **safe**, **flexible**, and **lightweight** dependency injection library designed for JS/TS projects of any complexity. It offers **strict static typing** with an **immutable container**, ensuring reliability and clarity in your code. With **zero dependencies**, it works in any modern JavaScript environment out of the box — true **plug & play**.
+`@spirex/di` is a **powerful**, **lightweight**, and **predictable** dependency injection library for JavaScript and TypeScript. 
+
+It enforces strict TypeScript typing through a **TypeMap**, uses an **immutable container** built via a fluent builder API, and supports **modular**, reusable configurations. With **zero dependencies**, **advanced scope management**, and **extensible middleware**, it keeps your code clean, testable, and flexible without imposing any runtime boilerplate. 
+
+Fully **plug & play** and production-ready, **SpireX/DI** is ideal for enterprise projects, helping teams manage complex service graphs effortlessly while simplifying long-term maintenance.
 
 ## Features
 - **Immutable container** — no hidden runtime mutations;
@@ -16,7 +20,7 @@
 - **Lifecycle management** — singleton, lazy, scope, transient;
 - Middleware support;
 - Named bindings, aliases & conflict resolution strategies.
-- Zero dependencies, runs on pure JS, **only ~9KB**.
+- Zero dependencies, runs on pure JS, **only ~9.2KB** (~3.4kb gzipped).
 
 ## Install
 ```sh

--- a/packages/di/changelog/v1.1.0.md
+++ b/packages/di/changelog/v1.1.0.md
@@ -1,0 +1,221 @@
+# SpireX/DI — v1.1.0 Change Log
+
+Version 1.1.0 introduces a set of improvements aimed at making dependency management more flexible, type-safe, and observable.
+The update expands the Middleware API, enhances builder introspection, strengthens factoryOf, and improves scoped bindings and metadata typing.
+
+Together, these changes make **SpireX/DI** easier to extend and safer to use in large or highly modular applications.
+
+## Middleware Enhancements
+
+### `onPreBuild` Hook
+A new `onPreBuild` hook is executed **before container build starts**.
+It allows middleware to validate builder state, inspect existing bindings, or register additional bindings required for middleware operation.
+
+This hook is especially useful for enforcing constraints or preparing internal services before the container is finalized.
+
+```js
+builder.use({
+    onPreBuild(builder) {
+        builder.findEntry(entry => entry.type === 'config');
+        builder.bindInstance('internalLogger', loggerInstance);
+        builder.hasModule('core');
+    },
+});
+```
+
+### `onPostBuild` Hook
+The new `onPostBuild` hook runs after the container has been successfully built and all singletons are activated.
+
+It enables final verification and eager configuration of services before the container is exposed to the application.
+
+```js
+builder.use({
+    onPostBuild(container) {
+        container.maybe('service');
+        container.scope('ui').get('sharedStore');
+        container.get('logger').time('di-ready');
+    },
+});
+```
+This hook is ideal for health checks, warm-up logic, or instrumentation.
+
+### Builder Access in `onBind`
+The `onBind` hook now receives a reference to the **current builder**.
+
+This allows bindings to react dynamically to other bindings, enabling advanced patterns such as grouping, aliasing, or conditional registration.
+
+```js
+builder.use({
+    onBind(entry, origin, builder) {
+        if (entry.type === 'cmdHandler' && entry.name) {
+            builder.bindAlias('cmdHandler', entry.type, {
+                originName: entry.name,
+                ifConflict: 'append',
+            });
+        }
+        return entry;
+    },
+});
+```
+
+### Activation Stack in `onActivated`
+The `onActivated` hook now provides an **activation stack**, showing the full dependency chain that caused an instance to be created.
+
+This makes it possible to understand who requested a dependency and why it was activated.
+
+```js
+builder.use({
+    onActivated(entry, instance, scope, stack) {
+        // Example stack:
+        // ['viewModel', 'interceptor', 'repo', 'http']
+        // The current type is the last element.
+        // The initiator of activation is the first element.
+    },
+});
+```
+This feature enables advanced diagnostics, conditional decoration, and tracing.
+
+### Typed Middleware with `TypeMap`
+Middleware can now define its own `TypeMap` and **inherit** the container’s `TypeMap`.
+
+This allows middleware to:
+- Register new types without splitting logic into a module;
+- Access container types with full TypeScript type checking;
+- Use `onUse` and `onPreBuild` hooks with strong typing.
+
+
+```ts
+diBuilder<{ service: MyService }>().use({
+    onUse(builder) {
+        // builder:
+        // IContainerBuilder<{ service: MyService }>
+        builder.findEntry('service') 
+    }
+})
+```
+This significantly improves middleware authoring ergonomics and safety.
+
+
+## Scoped Factory Bindings
+Factory bindings can now be declared as their **own scope** using `withScope` option.
+
+When enabled, a new scope is created **per type key**, and both the instance and its dependencies are resolved within that scope.
+
+```ts
+builder.bindFactory(
+    'typeKey',
+    factoryOf(MyService),
+    { withScope: true },
+);
+```
+This is useful for isolating stateful services or implementing per-feature lifetimes.
+
+## Strongly Typed Binding Metadata
+
+### Typed Metadata Dictionary
+Binding metadata is now described using the generic type
+`TTypeEntryMeta<TypeMap, TypeKey>` with values of `ITypeEntryMetaData<TypeMap, TypeKey>`.
+
+Metadata can now:
+- Reference other container types safely;
+- Access the current type key;
+- Fail at compile time if referenced types are renamed or missing.
+
+```ts
+function spy<TypeMap extends TTypeMapBase, T>(
+    logger: keyof TypeMapFilterByType<TypeMap, ILogger>,
+): ITypeEntryMeta<TypeMap, T> {
+    return {
+        spy: { logger },
+    };
+}
+
+builder.bindFactory('service', factoryOf(MyService), {
+    meta: spy('appLogger'),
+});
+```
+This enables metadata-driven tooling while preserving full type safety.
+
+
+## Builder Inspection and Entry Search
+
+### `find` and `findAll` Methods
+The builder now provides `find` and `findAll` methods for searching type bindings using a predicate.
+
+- `find` returns the first matching entry
+- `findAll` returns all matching entries
+
+These methods are available:
+- On the builder itself
+- Inside middleware hooks: `onUse`, `onBind`, `onPreBuild`
+
+```js
+builder.find(entry => entry.meta?.spy !== undefined);
+builder.findAll(entry => entry.scope === 'ui');
+```
+
+## `factoryOf` Improvements
+
+### Frozen Class Dependencies
+Class dependency lists captured by `factoryOf` are now **frozen at registration time**.
+
+This prevents accidental or malicious runtime modification of constructor dependency metadata after factory registration.
+
+### `factoryOf` for Factory Functions
+`factoryOf` now supports **plain factory functions**, reducing boilerplate for manual dependency extraction.
+
+```js
+builder.bindFactory(
+    'service',
+    factoryOf(
+        makeService,
+        ['user', 'eventBus', 'repo', 'logger'],
+    ),
+);
+
+// Equivalent to:
+builder.bindFactory('service', r =>
+    makeService(
+        r.get('user'),
+        r.get('eventBus'),
+        r.get('repo'),
+        r.get('logger'),
+    ),
+);
+```
+
+### Fast-Fail Dependency Validation
+Because `factoryOf` knows all dependency keys in advance, they are now **validated during container build**.
+
+If a required dependency is missing, container construction fails immediately—similar to `bindSafeFactory`.
+
+```ts
+const container = diBuilder<{
+    auth: AuthService;
+    authGateway: IAuthGateway;
+}>()
+    .bindFactory('auth', factoryOf(AuthService))
+    .build(); // Throws: 'authGateway' is not bound
+```
+This provides safer defaults without sacrificing performance.
+
+## Falsy Branch Support in `when`
+The `when` operator now supports an optional **falsy branch**, removing the need to define two separate conditions.
+```ts
+builder.when(
+    condition,
+    (binder) => { /* truthy branch */ },
+    (binder) => { /* falsy branch */ },
+);
+```
+This simplifies conditional binding logic and improves readability.
+
+----------------
+## Summary
+
+**SpireX/DI v1.1.0** significantly enhances middleware extensibility, lifecycle visibility, and type safety.
+Developers gain new lifecycle hooks, better diagnostics through activation stacks, and more powerful builder analysis tools.
+
+`factoryOf` becomes safer and more expressive, while typed metadata and scoped bindings unlock advanced architectural patterns.
+
+Overall, this release makes dependency management more predictable, observable, and maintainable in complex applications.

--- a/packages/di/src/index.d.ts
+++ b/packages/di/src/index.d.ts
@@ -52,6 +52,21 @@ export interface ITypeEntryMetaData<
 export type TProvider<T> = () => T;
 
 /**
+ * Predicate function used to filter or match type bindings.
+ * 
+ * The predicate is applied to a type entry and should return `true`
+ * if the entry satisfies the required condition.
+ * 
+ * @template TypeMap A map of container types used for strict typing.
+ * @param typeEntry An immutable type entry representing a single container binding.
+ * @returns `true` if the type entry matches the predicate condition, otherwise `false`.
+ * 
+ * @since 1.1.0
+ */
+export type TTypeEntryPredicate<TypeMap extends TTypeMapBase> =
+    (typeEntry: TTypeEntry<TypeMap, keyof TypeMap>) => boolean
+
+/**
  * A factory function that produces an instance of a type from the container.
  *
  * @typeParam TypeMap - A mapping of tokens to their corresponding instance types.
@@ -920,6 +935,8 @@ export interface IContainerBuilder<TypeMap extends TTypeMapBase>
      * @param name - Optional name qualifier.
      *
      * @returns A type entry if found, or `undefined` if not bound.
+     * 
+     * @deprecated since 1.1.0 - Use 'find' method instead.
      */
     findEntry(
         type: keyof TypeMap,
@@ -935,11 +952,34 @@ export interface IContainerBuilder<TypeMap extends TTypeMapBase>
      * @param type - The type for which to retrieve binding entries.
      * @param name - Optional name qualifier of the binding, if named bindings are used.
      * @returns An array of all matching binding entries. Returns an empty array if none are found.
+     * 
+     * @deprecated since 1.1.0 - Use 'findAll' method instead.
      */
     findAllEntries(
         type: keyof TypeMap,
         name?: string,
     ): Readonly<TTypeEntry<TypeMap, typeof type>>[];
+
+    /**
+     * Finds the first container entry that matches the given predicate.
+     * The returned entry is frozen and can't to be mutated.
+     *
+     * @param predicate - A function that receives a type-entry and returns `true` if it should be selected.
+     * @returns The first entry matching the predicate, or `undefined` if no entry matches.
+     * 
+     * @since 1.1.0
+     */
+    find(predicate: TTypeEntryPredicate<TypeMap>): Readonly<TTypeEntry<TypeMap, keyof TypeMap>> | undefined;
+
+    /**
+     * Finds all container entries matching a given condition.
+     *
+     * @param predicate — A function that receives a container entry and returns `true` for entries to include in the result.
+     * @returns An array of entries that satisfy the predicate. Returns an empty array if none match.
+     * 
+     * @since 1.1.0
+     */
+    findAll(predicate: TTypeEntryPredicate<TypeMap>): Readonly<TTypeEntry<TypeMap, keyof TypeMap>>[];
 
     /**
      * Returns the origin type reference that an alias points to, if any.

--- a/packages/di/src/index.d.ts
+++ b/packages/di/src/index.d.ts
@@ -53,18 +53,19 @@ export type TProvider<T> = () => T;
 
 /**
  * Predicate function used to filter or match type bindings.
- * 
+ *
  * The predicate is applied to a type entry and should return `true`
  * if the entry satisfies the required condition.
- * 
+ *
  * @template TypeMap A map of container types used for strict typing.
  * @param typeEntry An immutable type entry representing a single container binding.
  * @returns `true` if the type entry matches the predicate condition, otherwise `false`.
- * 
+ *
  * @since 1.1.0
  */
-export type TTypeEntryPredicate<TypeMap extends TTypeMapBase> =
-    (typeEntry: TTypeEntry<TypeMap, keyof TypeMap>) => boolean
+export type TTypeEntryPredicate<TypeMap extends TTypeMapBase> = (
+    typeEntry: TTypeEntry<TypeMap, keyof TypeMap>,
+) => boolean;
 
 /**
  * A factory function that produces an instance of a type from the container.
@@ -191,7 +192,7 @@ export type TFactoryBindingOptions<
      * Indicates that the factory should create a new scope when producing an instance.
      * @since 1.1.0
      */
-    withScope?: TScopeOptions | boolean
+    withScope?: TScopeOptions | boolean;
 };
 
 /** Options for configuring an alias binding. */
@@ -448,7 +449,7 @@ export type TContainerMiddlewareOnResolve<
 
 /**
  * A hook that runs before the container is built.
- * 
+ *
  * Called right before the build process starts, allowing middleware
  * to modify or extend the container builder configuration.
  *
@@ -461,7 +462,7 @@ export type TContainerMiddlewareOnPreBuild<
 
 /**
  * A hook that runs after the container is fully built.
- * 
+ *
  * Called immediately after the container construction is completed,
  * providing access to the root container scope.
  *
@@ -562,7 +563,11 @@ export interface ITypeEntryBinder<TypeMap extends TTypeMapBase> {
      * @param falsyDelegate - A function that declares bindings when the condition is false.
      * @returns The container builder instance for chaining.
      */
-    when(condition: boolean, truthyDelegate: TBinderDelegate<TypeMap>, falsyDelegate?: TBinderDelegate<TypeMap>): this;
+    when(
+        condition: boolean,
+        truthyDelegate: TBinderDelegate<TypeMap>,
+        falsyDelegate?: TBinderDelegate<TypeMap>,
+    ): this;
 
     /**
      * Injects dependencies from the container into an external object or service.
@@ -868,7 +873,7 @@ export interface IContainerScope<TypeMap extends TTypeMapBase>
 
     /**
      * Indicates whether this scope is isolated from its parent scopes.
-     * 
+     *
      * When `true`, the scope does not inherit instances from parent containers,
      * except for instances provided by the root container (e.g. shared singletons).
      * This allows the scope to have its own isolated instance graph while still
@@ -880,7 +885,7 @@ export interface IContainerScope<TypeMap extends TTypeMapBase>
 
     /**
      * Indicates whether this scope is sealed.
-     * 
+     *
      * When `true`, no child scopes can be created from this scope.
      * This is useful for enforcing strict scope boundaries and preventing
      * further scope hierarchy expansion.
@@ -964,8 +969,6 @@ export interface IContainerBuilder<TypeMap extends TTypeMapBase>
      * @param name - Optional name qualifier.
      *
      * @returns A type entry if found, or `undefined` if not bound.
-     * 
-     * @deprecated since 1.1.0 - Use 'find' method instead.
      */
     findEntry(
         type: keyof TypeMap,
@@ -981,8 +984,6 @@ export interface IContainerBuilder<TypeMap extends TTypeMapBase>
      * @param type - The type for which to retrieve binding entries.
      * @param name - Optional name qualifier of the binding, if named bindings are used.
      * @returns An array of all matching binding entries. Returns an empty array if none are found.
-     * 
-     * @deprecated since 1.1.0 - Use 'findAll' method instead.
      */
     findAllEntries(
         type: keyof TypeMap,
@@ -995,20 +996,24 @@ export interface IContainerBuilder<TypeMap extends TTypeMapBase>
      *
      * @param predicate - A function that receives a type-entry and returns `true` if it should be selected.
      * @returns The first entry matching the predicate, or `undefined` if no entry matches.
-     * 
+     *
      * @since 1.1.0
      */
-    find(predicate: TTypeEntryPredicate<TypeMap>): Readonly<TTypeEntry<TypeMap, keyof TypeMap>> | undefined;
+    find(
+        predicate: TTypeEntryPredicate<TypeMap>,
+    ): Readonly<TTypeEntry<TypeMap, keyof TypeMap>> | undefined;
 
     /**
      * Finds all container entries matching a given condition.
      *
      * @param predicate — A function that receives a container entry and returns `true` for entries to include in the result.
      * @returns An array of entries that satisfy the predicate. Returns an empty array if none match.
-     * 
+     *
      * @since 1.1.0
      */
-    findAll(predicate: TTypeEntryPredicate<TypeMap>): Readonly<TTypeEntry<TypeMap, keyof TypeMap>>[];
+    findAll(
+        predicate: TTypeEntryPredicate<TypeMap>,
+    ): Readonly<TTypeEntry<TypeMap, keyof TypeMap>>[];
 
     /**
      * Returns the origin type reference that an alias points to, if any.
@@ -1181,9 +1186,11 @@ export declare function factoryOf<
     TypeKey extends keyof TypeMap,
     InjectTuple extends readonly (keyof TypeMap)[],
 >(
-    factoryFn: (...args: { [T in keyof InjectTuple]: TypeMap[InjectTuple[T]] }) => TypeMap[TypeKey],
+    factoryFn: (
+        ...args: { [T in keyof InjectTuple]: TypeMap[InjectTuple[T]] }
+    ) => TypeMap[TypeKey],
     injectTuple: InjectTuple,
-): TTypeFactory<TypeMap, TypeKey>
+): TTypeFactory<TypeMap, TypeKey>;
 
 /**
  * Creates a new dependency injection container builder.

--- a/packages/di/src/index.d.ts
+++ b/packages/di/src/index.d.ts
@@ -395,6 +395,32 @@ export type TContainerMiddlewareOnResolve = (
 ) => {};
 
 /**
+ * A hook that runs before the container is built.
+ * 
+ * Called right before the build process starts, allowing middleware
+ * to modify or extend the container builder configuration.
+ *
+ * @template TypeMap - The type map defining all bindings in the container.
+ * @param builder - Reference to the container builder being configured.
+ */
+export type TContainerMiddlewareOnPreBuild<
+    TypeMap extends TTypeMapBase = AnyTypeMap,
+> = (builder: IContainerBuilder<TypeMap>) => void;
+
+/**
+ * A hook that runs after the container is fully built.
+ * 
+ * Called immediately after the container construction is completed,
+ * providing access to the root container scope.
+ *
+ * @template TypeMap - The type map defining all bindings in the container.
+ * @param root - Reference to the built container (root scope).
+ */
+export type TContainerMiddlewareOnPostBuild<
+    TypeMap extends TTypeMapBase = AnyTypeMap,
+> = (root: IContainerScope<TypeMap>) => void;
+
+/**
  * A middleware hook that is called during scope lifecycle events.
  *
  * It receives the scope instance that is currently being opened or disposed.
@@ -419,7 +445,13 @@ export interface IContainerMiddleware<TypeMap extends TTypeMapBase = AnyTypeMap>
     onUse?: TContainerBuilderMiddlewareOnUse;
 
     /** Triggered when a new type entry is being bound */
-    onBind?: TContainerBuilderMiddlewareOnBind;
+    onBind?: TContainerBuilderMiddlewareOnBind<TypeMap>;
+
+    /** A hook that runs before the container is built. */
+    onPreBuild?: TContainerMiddlewareOnPreBuild<TypeMap>;
+
+    /** A hook that runs after the container is fully built. */
+    onPostBuild?: TContainerMiddlewareOnPostBuild<TypeMap>;
 
     /** Triggered whenever a instance is requested from the container. */
     onRequest?: TContainerMiddlewareOnRequest;
@@ -471,10 +503,11 @@ export interface ITypeEntryBinder<TypeMap extends TTypeMapBase> {
     /**
      * Conditionally applies bindings based on the provided boolean condition.
      * @param condition - The condition to evaluate.
-     * @param delegate - A function that declares bindings when the condition is true.
+     * @param truthyDelegate - A function that declares bindings when the condition is true.
+     * @param falsyDelegate - A function that declares bindings when the condition is false.
      * @returns The container builder instance for chaining.
      */
-    when(condition: boolean, delegate: TBinderDelegate<TypeMap>): this;
+    when(condition: boolean, truthyDelegate: TBinderDelegate<TypeMap>, falsyDelegate?: TBinderDelegate<TypeMap>): this;
 
     /**
      * Injects dependencies from the container into an external object or service.

--- a/packages/di/src/index.d.ts
+++ b/packages/di/src/index.d.ts
@@ -186,6 +186,12 @@ export type TFactoryBindingOptions<
 > = TTypeBindingOptions<TypeMap, T> & {
     /** Determines how and when the instance is created and cached. */
     lifecycle?: TLifecycle;
+
+    /**
+     * Indicates that the factory should create a new scope when producing an instance.
+     * @since 1.1.0
+     */
+    withScope?: TScopeOptions | boolean
 };
 
 /** Options for configuring an alias binding. */
@@ -859,6 +865,29 @@ export interface IContainerScope<TypeMap extends TTypeMapBase>
 
     /** Scope hierarchy */
     readonly path: readonly string[];
+
+    /**
+     * Indicates whether this scope is isolated from its parent scopes.
+     * 
+     * When `true`, the scope does not inherit instances from parent containers,
+     * except for instances provided by the root container (e.g. shared singletons).
+     * This allows the scope to have its own isolated instance graph while still
+     * accessing globally shared dependencies.
+     *
+     * @since 1.1.0
+     */
+    readonly isolated: boolean;
+
+    /**
+     * Indicates whether this scope is sealed.
+     * 
+     * When `true`, no child scopes can be created from this scope.
+     * This is useful for enforcing strict scope boundaries and preventing
+     * further scope hierarchy expansion.
+     *
+     * @since 1.1.0
+     */
+    readonly sealed: boolean;
 
     /**
      * Indicates whether the scope has been disposed.

--- a/packages/di/src/index.d.ts
+++ b/packages/di/src/index.d.ts
@@ -1146,3 +1146,39 @@ export type TypeMapOf<T> = T extends
     | TTypeEntry<infer TypeMap, any>
     ? TypeMap
     : never;
+
+/**
+ * Extracts type map that includes only entries whose value type
+ * is assignable to the specified type `T`.
+ *
+ * @template TypeMap - The original type map to filter.
+ * @template T       - The target type to match against.
+ *
+ * @example
+ * type TypeMap = { logger: ILogger; http: HttpService };
+ * type LoggerEntries = TypeMapFilterByType<TypeMap, ILogger>;
+ * // Result: { logger: ILogger }
+ */
+export type TypeMapFilterByType<TypeMap extends TTypeMapBase, T> = {
+    [K in keyof TypeMap as TypeMap[K] extends T ? K : never]: TypeMap[K];
+};
+
+/**
+ * Extracts type map that includes only entries whose value type
+ * exactly matches the specified type `T` (both assignable directions must hold).
+ *
+ * @template TypeMap - The original type map to filter.
+ * @template T        - The exact type to match against.
+ *
+ * @example
+ * type TypeMap = { logger: ILogger; consoleLogger: ConsoleLogger };
+ * type ExactLoggers = TypeMapFilterByExactType<TypeMap, ILogger>;
+ * // Result: { logger: ILogger }
+ */
+export type TypeMapFilterByExactType<TypeMap extends TTypeMapBase, T> = {
+    [K in keyof TypeMap as [TypeMap[K]] extends [T]
+        ? [T] extends [TypeMap[K]]
+            ? K
+            : never
+        : never]: TypeMap[K];
+};

--- a/packages/di/src/index.js
+++ b/packages/di/src/index.js
@@ -972,8 +972,12 @@ export function staticModule(id) {
     };
 }
 
-export function factoryOf(Class) {
+const mapInject = (r,i) => i.map(t => r.get(t))
+export function factoryOf(Class, inject) {
+    if (Array.isArray(inject))
+        return (r) => Class(...mapInject(r, inject))
+
     return (r) => Array.isArray(Class.inject)
-        ? new Class(...Class.inject.map((t) => r.get(t)))
+        ? new Class(...mapInject(r, Class.inject))
         : new Class();
 }

--- a/packages/di/src/index.js
+++ b/packages/di/src/index.js
@@ -847,8 +847,9 @@ export function diBuilder(builderOptions) {
         return this;
     }
 
-    function when(condition, delegate) {
-        if (condition) delegate(this);
+    function when(condition, truthyDelegate, falsyDelegate) {
+        if (condition) truthyDelegate && truthyDelegate(this);
+        else falsyDelegate && falsyDelegate(this)
         return this;
     }
 
@@ -914,6 +915,8 @@ export function diBuilder(builderOptions) {
     }
 
     function build() {
+        blueprint.callMw("onPreBuild", -1, this)
+
         // Compile aliases
         blueprint.compileAliases();
 
@@ -928,6 +931,7 @@ export function diBuilder(builderOptions) {
 
         var container = createRootContainerScope(blueprint);
         externalInjections.forEach((delegate) => delegate(container));
+        blueprint.callMw("onPostBuild", -1, container)
         return container;
     }
 

--- a/packages/di/src/index.js
+++ b/packages/di/src/index.js
@@ -529,6 +529,9 @@ function createRootContainerScope(blueprint) {
             // Attempt to get cached instance from current scope
             instance = scope[$locals].get(entry);
             if (!instance && !noActivate) {
+                if (entry.withScope)
+                    scope = scope.scope(entry.type, entry.withScope)
+
                 instance = activateInstance(entry, scope);
 
                 // Cache the instance in scope locals if lifecycle is not transient
@@ -840,6 +843,7 @@ export function diBuilder(builderOptions) {
                 factory,
                 lifecycle,
                 name: options && options.name,
+                withScope: options && options.withScope,
                 module: moduleStack[moduleStack.length - 1],
                 allowedScopes: options && options.allowedScopes,
                 meta: options && options.meta,

--- a/packages/di/src/index.test.mjs
+++ b/packages/di/src/index.test.mjs
@@ -27,6 +27,8 @@ function catchError(procedure) {
     return undefined;
 }
 
+function noop() {}
+
 // @ts-nocheck
 describe("Container Builder", () => {
     describe("Create", () => {
@@ -525,10 +527,10 @@ describe("Container Builder", () => {
                 var typeKey = "typeKey";
                 var name = "typeName";
                 var builder = diBuilder();
-                builder.bindFactory(typeKey, () => {});
+                builder.bindFactory(typeKey, noop);
 
                 // Act -----------
-                builder.bindFactory(typeKey, () => {}, { name });
+                builder.bindFactory(typeKey, noop, { name });
                 var entryWithoutName = builder.findEntry(typeKey);
                 var entryWithName = builder.findEntry(typeKey, name);
 
@@ -569,7 +571,7 @@ describe("Container Builder", () => {
 
                     // Act -----------
                     var err = catchError(() =>
-                        builder.bindFactory(typeKey, () => {}),
+                        builder.bindFactory(typeKey, noop),
                     );
                     var entry = builder.findEntry(typeKey);
 
@@ -592,7 +594,7 @@ describe("Container Builder", () => {
                     builder.bindFactory(typeKey, expectedFactory);
 
                     // Act ---------
-                    builder.bindFactory(typeKey, () => {}, {
+                    builder.bindFactory(typeKey, noop, {
                         ifConflict: "keep",
                     });
                     var entry = builder.findEntry(typeKey);
@@ -609,7 +611,7 @@ describe("Container Builder", () => {
                     var typeKey = "typeKey";
                     var expectedFactory = vi.fn();
                     var builder = diBuilder();
-                    builder.bindFactory(typeKey, () => {});
+                    builder.bindFactory(typeKey, noop);
 
                     // Act ---------
                     builder.bindFactory(typeKey, expectedFactory, {
@@ -632,7 +634,7 @@ describe("Container Builder", () => {
                     var builder = diBuilder({
                         ifConflict: expectedStrategy,
                     });
-                    builder.bindFactory(typeKey, () => {});
+                    builder.bindFactory(typeKey, noop);
 
                     // Act -----------
                     builder.bindFactory(typeKey, expectedFactory);
@@ -648,7 +650,7 @@ describe("Container Builder", () => {
                 test("WHEN strategy 'append' for first bind", () => {
                     // Arrange --------
                     var typeKey = "typeKey";
-                    var expectedFactory = () => {};
+                    var expectedFactory = noop;
                     var builder = diBuilder();
 
                     // Act ------------
@@ -695,12 +697,12 @@ describe("Container Builder", () => {
                 test("WHEN strategy 'replace' after 'append'", () => {
                     // Arrange ----------
                     var typeKey = "typeKey";
-                    var expectedFactory = () => {};
+                    var expectedFactory = noop;
                     var builder = diBuilder()
-                        .bindFactory(typeKey, () => {}, {
+                        .bindFactory(typeKey, noop, {
                             ifConflict: "append",
                         })
-                        .bindFactory(typeKey, () => {}, {
+                        .bindFactory(typeKey, noop, {
                             ifConflict: "append",
                         });
 
@@ -777,7 +779,7 @@ describe("Container Builder", () => {
                     var builder = diBuilder();
 
                     // Act ------------
-                    builder.bindFactory(typeKey, () => {});
+                    builder.bindFactory(typeKey, noop);
                     var entry = builder.findEntry(typeKey);
 
                     // Assert ---------
@@ -794,7 +796,7 @@ describe("Container Builder", () => {
                     });
 
                     // Act ------------
-                    builder.bindFactory(typeKey, () => {});
+                    builder.bindFactory(typeKey, noop);
                     var entry = builder.findEntry(typeKey);
 
                     // Assert ---------
@@ -809,7 +811,7 @@ describe("Container Builder", () => {
                     var builder = diBuilder();
 
                     // Act -----------
-                    builder.bindFactory(typeKey, () => {}, {
+                    builder.bindFactory(typeKey, noop, {
                         lifecycle: expectedLifecycle,
                     });
                     var entry = builder.findEntry(typeKey);
@@ -916,7 +918,7 @@ describe("Container Builder", () => {
                     // Act -------------
                     builder.bindSafeFactory(
                         typeKey,
-                        () => {},
+                        noop,
                         () => 42,
                         { meta: typeMeta },
                     );
@@ -944,8 +946,8 @@ describe("Container Builder", () => {
                     var err = catchError(() =>
                         builder.bindSafeFactory(
                             typeKey,
-                            () => {},
-                            () => {},
+                            noop,
+                            noop,
                         ),
                     );
                     var entry = builder.findEntry(typeKey);
@@ -978,8 +980,8 @@ describe("Container Builder", () => {
                     // Act ---------
                     builder.bindSafeFactory(
                         typeKey,
-                        () => {},
-                        () => {},
+                        noop,
+                        noop,
                         {
                             ifConflict: "keep",
                         },
@@ -1003,8 +1005,8 @@ describe("Container Builder", () => {
                     var builder = diBuilder();
                     builder.bindSafeFactory(
                         typeKey,
-                        () => {},
-                        () => {},
+                        noop,
+                        noop,
                     );
 
                     // Act ---------
@@ -1037,8 +1039,8 @@ describe("Container Builder", () => {
                     });
                     builder.bindSafeFactory(
                         typeKey,
-                        () => {},
-                        () => {},
+                        noop,
+                        noop,
                     );
 
                     // Act -----------
@@ -1311,7 +1313,7 @@ describe("Container Builder", () => {
                     builder.when(condition, (binder) =>
                         binder
                             .bindInstance(instanceKey, 42)
-                            .bindFactory(factoryKey, () => {})
+                            .bindFactory(factoryKey, noop)
                             .bindAlias(aliasKey, instanceKey),
                     );
 
@@ -1327,6 +1329,20 @@ describe("Container Builder", () => {
                     );
                 },
             );
+
+            test.each([true, false])("WHEN: falsy branch with '%s' condition", (isTruthy) => {
+                // Arrange ----
+                var truthyBranchFn = vi.fn()
+                var falsyBranchFn = vi.fn()
+
+                // Act --------
+                var builder = diBuilder()
+                    .when(isTruthy, truthyBranchFn, falsyBranchFn)
+
+                // Assert -----
+                expect(isTruthy ? truthyBranchFn: falsyBranchFn).toHaveBeenCalledWith(builder)
+                expect(isTruthy ? falsyBranchFn: truthyBranchFn).not.toHaveBeenCalled()
+            })
         });
     });
 
@@ -1487,7 +1503,7 @@ describe("Container Builder", () => {
 
                 // Assert -------------
                 expect(entry).toBeDefined();
-                expect(onBindMock).toHaveBeenCalledWith(entry, entry);
+                expect(onBindMock).toHaveBeenCalledWith(entry, entry, builder);
             });
 
             test("WHEN bind factory", () => {
@@ -1499,13 +1515,13 @@ describe("Container Builder", () => {
                 });
 
                 // Act ----------------
-                builder.bindFactory(typeKey, () => {});
+                builder.bindFactory(typeKey, noop);
 
                 var entry = builder.findEntry(typeKey);
 
                 // Assert -------------
                 expect(entry).toBeDefined();
-                expect(onBindMock).toHaveBeenCalledWith(entry, entry);
+                expect(onBindMock).toHaveBeenCalledWith(entry, entry, builder);
             });
 
             test("WHEN modify entry with onBind one middleware", () => {
@@ -1627,7 +1643,7 @@ describe("Container Builder", () => {
                 // Arrange -------
                 var typeKey = "typeKey";
                 var builder = diBuilder().use({
-                    onBind: () => {}, // Oh no, type entry return was forgotten :(
+                    onBind: noop, // Oh no, type entry return was forgotten :(
                 });
 
                 // Act -----------
@@ -1675,7 +1691,7 @@ describe("Container Builder", () => {
                 // Act --------------
                 builder
                     .bindInstance("instanceKey", 42)
-                    .bindFactory("factoryKey", () => {});
+                    .bindFactory("factoryKey", noop);
 
                 var instanceEntry = builder.findEntry("instanceKey");
                 var factoryEntry = builder.findEntry("factoryKey");
@@ -1686,6 +1702,126 @@ describe("Container Builder", () => {
                 expect(factoryEntry).toBeDefined();
             });
         });
+
+        describe("onPreBuild hook", () => {
+            test("WHEN: use onPreBuild & bind types", () => {
+                // Arrange ------
+                var onPreBuild = vi.fn();
+
+                var builder = diBuilder()
+
+                // Act ----------
+                builder
+                    .use({ onPreBuild })
+                    .bindFactory("typeA", noop)
+                    .bindInstance("typeB", 42)
+
+                // Assert -------
+                expect(onPreBuild).not.toHaveBeenCalled();
+            });
+
+            test("WHEN: build container", () => {
+                // Arrange ------
+                var onPreBuild = vi.fn();
+
+                var builder = diBuilder()
+                    .use({ onPreBuild })
+                    .bindFactory("typeA", noop)
+                    .bindInstance("typeB", 42);
+
+                // Act ----------
+                builder.build();
+
+                // Assert -------
+                expect(onPreBuild).toHaveBeenCalledExactlyOnceWith(builder);
+            });
+
+            test("WHEN: add many onPreBuild hooks", () => {
+                // Arrange ------
+                var onPreBuildA = vi.fn();
+                var onPreBuildB = vi.fn();
+                var onPreBuildC = vi.fn();
+
+                var builder = diBuilder();
+
+                // Act ----------
+                builder
+                    .use({ onPreBuild: onPreBuildA })
+                    .use({ onPreBuild: onPreBuildB })
+                    .use({ onPreBuild: onPreBuildC })
+                    .build()
+
+                // Assert -------
+                expect(onPreBuildA).toHaveBeenCalledExactlyOnceWith(builder)
+
+                expect(onPreBuildB).toHaveBeenCalledExactlyOnceWith(builder)
+                expect(onPreBuildB).toHaveBeenCalledAfter(onPreBuildA)
+
+                expect(onPreBuildC).toHaveBeenCalledExactlyOnceWith(builder)
+                expect(onPreBuildC).toHaveBeenCalledAfter(onPreBuildB)
+            })
+        });
+
+        describe("onPostBuild hook", () => {
+            test("WHEN: use onPostBuild & bind types", () => {
+                // Arrange ----------
+                var onPostBuild = vi.fn();
+
+                var builder = diBuilder()
+
+                // Act --------------
+                builder
+                    .use({ onPostBuild })
+                    .bindFactory("typeA", noop)
+                    .bindInstance("typeB", 42)
+
+                // Assert -----------
+                expect(onPostBuild).not.toHaveBeenCalled()
+            })
+
+            test("WHEN: build container", () => {
+                // Arrange ------
+                var onPreBuild = vi.fn();
+                var onPostBuild = vi.fn();
+
+                var builder = diBuilder()
+                    .use({ onPreBuild, onPostBuild })
+                    .bindFactory("typeA", noop)
+                    .bindInstance("typeB", 42)
+
+                // Act ----------
+                var container = builder.build();
+
+                // Assert --------
+                expect(onPostBuild).toHaveBeenCalledExactlyOnceWith(container)
+                expect(onPostBuild).toHaveBeenCalledAfter(onPreBuild)
+            })
+
+            test("WHEN: add many onPostBuild hooks", () => {
+                // Arrange ------
+                var onPostBuildA = vi.fn();
+                var onPostBuildB = vi.fn();
+                var onPostBuildC = vi.fn();
+
+                var builder = diBuilder();
+
+                // Act ----------
+                var container = builder
+                    .use({ onPostBuild: onPostBuildA })
+                    .use({ onPostBuild: onPostBuildB })
+                    .use({ onPostBuild: onPostBuildC })
+                    .build()
+
+                // Assert -------
+                expect(onPostBuildA).toHaveBeenCalledExactlyOnceWith(container)
+
+                expect(onPostBuildB).toHaveBeenCalledExactlyOnceWith(container)
+                expect(onPostBuildB).toHaveBeenCalledAfter(onPostBuildA)
+
+                expect(onPostBuildC).toHaveBeenCalledExactlyOnceWith(container)
+                expect(onPostBuildC).toHaveBeenCalledAfter(onPostBuildB)
+            })
+        })
     });
 
     describe("Building container", () => {
@@ -3295,6 +3431,7 @@ describe("Container Scope", () => {
                     entry,
                     expectedInst,
                     container,
+                    [entry],
                 );
                 expect(onActivatedHandler).toHaveReturnedWith(expectedInst);
             });
@@ -3332,6 +3469,7 @@ describe("Container Scope", () => {
                     entry,
                     factoryInst,
                     container,
+                    [entry],
                 );
                 expect(onActivatedHandler).toHaveReturnedWith(expectedInst);
             });
@@ -3374,6 +3512,7 @@ describe("Container Scope", () => {
                     entry,
                     originValue,
                     container,
+                    [entry]
                 );
                 expect(onActivatedOne).toHaveReturnedWith(valueOne);
 
@@ -3383,9 +3522,36 @@ describe("Container Scope", () => {
                     entry,
                     valueOne,
                     container,
+                    [entry]
                 );
                 expect(onActivatedTwo).toHaveReturnedWith(valueTwo);
             });
+
+            test("WHEN: Deep activation", () => {
+                // Arrange ------
+                var typeKeyA = 'typeKeyA'
+                var typeKeyB = 'typeKeyB'
+
+                var onActivated = vi.fn((_, inst) => inst);
+
+                var builder = diBuilder()
+                    .use({ onActivated })
+                    .bindFactory(typeKeyA, () => 11, { lifecycle: 'lazy' })
+                    .bindFactory(typeKeyB, r => 22 + r.get(typeKeyA), { lifecycle: 'lazy' })
+
+                var typeEntryA = builder.findEntry(typeKeyA)
+                var typeEntryB = builder.findEntry(typeKeyB)
+
+                var container = builder.build();
+
+                // Act ----------
+                var instB = container.get(typeKeyB);
+                var instA = container.get(typeKeyA);
+
+                // Assert -------
+                expect(onActivated).toHaveBeenNthCalledWith(1, typeEntryA, instA, container, [typeEntryB, typeEntryA])
+                expect(onActivated).toHaveBeenNthCalledWith(2, typeEntryB, instB, container, [typeEntryB])
+            })
         });
     });
 

--- a/packages/di/src/index.test.mjs
+++ b/packages/di/src/index.test.mjs
@@ -703,9 +703,9 @@ describe("Container Builder", () => {
 
                 test("WHEN: class with unresolved deps", () => {
                     // Arrange -------
-                    var depKey = "dep"
+                    var depKey = "dep";
                     var classKey = "MyService";
-                    
+
                     class MyService {
                         static inject = [depKey];
                         constructor(value) {
@@ -713,8 +713,10 @@ describe("Container Builder", () => {
                         }
                     }
 
-                    var builder = diBuilder()
-                        .bindFactory(classKey, factoryOf(MyService))
+                    var builder = diBuilder().bindFactory(
+                        classKey,
+                        factoryOf(MyService),
+                    );
 
                     // Act ----------
 
@@ -722,53 +724,66 @@ describe("Container Builder", () => {
 
                     // Assert -------
                     expect(error).toBeInstanceOf(Error);
-                    expect(error.message).toEqual(DIErrors.MissingRequiredTypeError(depKey))
+                    expect(error.message).toEqual(
+                        DIErrors.MissingRequiredTypeError(depKey),
+                    );
                 });
 
                 test("WHEN: factory function with deps list", () => {
                     // Arrange ------
-                    var typeKey = 'typeKey'
-                    var factory = vi.fn((a, b) => ({ a, b }))
-    
-                    var depKeyA = 'depKeyA'
-                    var depValueA = 42
-                    var depKeyB = 'depKeyB'
-                    var depValueB = 'foo'
+                    var typeKey = "typeKey";
+                    var factory = vi.fn((a, b) => ({ a, b }));
 
+                    var depKeyA = "depKeyA";
+                    var depValueA = 42;
+                    var depKeyB = "depKeyB";
+                    var depValueB = "foo";
 
                     var builder = diBuilder()
-                        .bindFactory(typeKey, factoryOf(factory, [depKeyA, depKeyB]), { lifecycle: 'lazy' })
+                        .bindFactory(
+                            typeKey,
+                            factoryOf(factory, [depKeyA, depKeyB]),
+                            { lifecycle: "lazy" },
+                        )
                         .bindInstance(depKeyA, depValueA)
                         .bindInstance(depKeyB, depValueB)
-                        .build()
+                        .build();
 
                     // Act ----------
-                    var inst = builder.get(typeKey)
+                    var inst = builder.get(typeKey);
 
                     // Assert -------
-                    expect(factory).toHaveBeenCalledExactlyOnceWith(depValueA, depValueB)
-                    expect(inst).toBeInstanceOf(Object)
-                    expect(inst.a).toBe(depValueA)
-                    expect(inst.b).toBe(depValueB)
+                    expect(factory).toHaveBeenCalledExactlyOnceWith(
+                        depValueA,
+                        depValueB,
+                    );
+                    expect(inst).toBeInstanceOf(Object);
+                    expect(inst.a).toBe(depValueA);
+                    expect(inst.b).toBe(depValueB);
                 });
 
                 test("WHEN: factory function with unresolved deps", () => {
-                     // Arrange ------
-                    var typeKey = 'typeKey'
-                    var factory = vi.fn(value => ({ value }))
+                    // Arrange ------
+                    var typeKey = "typeKey";
+                    var factory = vi.fn((value) => ({ value }));
 
-                    var depKey = "value"
+                    var depKey = "value";
 
-                    var builder = diBuilder()
-                        .bindFactory(typeKey, factoryOf(factory, [depKey]), { lifecycle: 'lazy' })
+                    var builder = diBuilder().bindFactory(
+                        typeKey,
+                        factoryOf(factory, [depKey]),
+                        { lifecycle: "lazy" },
+                    );
 
                     // Act ----------
-                    var error = catchError(() => builder.build())
+                    var error = catchError(() => builder.build());
 
                     // Assert -------
-                    expect(error).toBeInstanceOf(Error)
-                    expect(error.message).toEqual(DIErrors.MissingRequiredTypeError(depKey))
-                    expect(factory).not.toHaveBeenCalled()
+                    expect(error).toBeInstanceOf(Error);
+                    expect(error.message).toEqual(
+                        DIErrors.MissingRequiredTypeError(depKey),
+                    );
+                    expect(factory).not.toHaveBeenCalled();
                 });
             });
 

--- a/packages/di/src/index.test.mjs
+++ b/packages/di/src/index.test.mjs
@@ -209,7 +209,7 @@ describe("Container Builder", () => {
                     .bindInstance(typeKey, 22, { name: typeNameB });
 
                 // Act --------------
-                var result = builder.find((e) => e.type === 'unknown');
+                var result = builder.find((e) => e.type === "unknown");
 
                 // Assert -----------
                 expect(result).toBeUndefined();
@@ -219,57 +219,59 @@ describe("Container Builder", () => {
         describe("findAll", () => {
             test("WHEN: Found one type entry", () => {
                 // Arrange -------
-                var typeKey = 'typeKey'
-                var typeName = 'typeName'
+                var typeKey = "typeKey";
+                var typeName = "typeName";
 
                 var builder = diBuilder()
                     .bindInstance(typeKey, 11)
-                    .bindInstance(typeKey, 22, { name: typeName })
-                    
+                    .bindInstance(typeKey, 22, { name: typeName });
+
                 // Act -----------
-                var result = builder.findAll(e => e.type === typeKey && e.name === typeName)
+                var result = builder.findAll(
+                    (e) => e.type === typeKey && e.name === typeName,
+                );
 
                 // Assert --------
-                expect(result).toHaveLength(1)
-                expect(result[0].instance).toBe(22)
-            })
+                expect(result).toHaveLength(1);
+                expect(result[0].instance).toBe(22);
+            });
 
             test("WHEN: Found many type entries", () => {
                 // Arrange ----------
-                var typeKey = 'typeKey'
+                var typeKey = "typeKey";
 
                 var builder = diBuilder()
-                    .bindInstance(typeKey, 11, { ifConflict: 'append' })
-                    .bindInstance(typeKey, 22, { ifConflict: 'append' })
-                    .bindInstance(typeKey, 33, { ifConflict: 'append' })
+                    .bindInstance(typeKey, 11, { ifConflict: "append" })
+                    .bindInstance(typeKey, 22, { ifConflict: "append" })
+                    .bindInstance(typeKey, 33, { ifConflict: "append" });
 
                 // Act --------------
-                var result = builder.findAll(e => e.type === typeKey)
+                var result = builder.findAll((e) => e.type === typeKey);
 
                 // Assert -----------
-                expect(result).toHaveLength(3)
+                expect(result).toHaveLength(3);
 
-                var values = result.map(e => e.instance)
-                expect(values).toContain(11)
-                expect(values).toContain(22)
-                expect(values).toContain(33)
-            })
+                var values = result.map((e) => e.instance);
+                expect(values).toContain(11);
+                expect(values).toContain(22);
+                expect(values).toContain(33);
+            });
 
             test("WHEN: no one type entry found", () => {
                 // Arrange ----
-                var typeKey = 'typeKey'
+                var typeKey = "typeKey";
 
                 var builder = diBuilder()
-                    .bindInstance(typeKey, 24, { ifConflict: 'append' })
-                    .bindInstance(typeKey, 42, { ifConflict: 'append' })
+                    .bindInstance(typeKey, 24, { ifConflict: "append" })
+                    .bindInstance(typeKey, 42, { ifConflict: "append" });
 
                 // Act --------
-                var result = builder.findAll(e => e.type === 'unknown')
+                var result = builder.findAll((e) => e.type === "unknown");
 
                 // Assert -----
-                expect(result).toHaveLength(0)
-            })
-        })
+                expect(result).toHaveLength(0);
+            });
+        });
     });
 
     describe("Binding", () => {
@@ -3834,6 +3836,76 @@ describe("Container Scope", () => {
                 );
                 expect(childScope.sealed).is.false;
                 expect(childScope.isolated).is.true;
+            });
+
+            test("WHEN: Create scope via factory binding", () => {
+                // Arrange ------
+                var typeKey = "typeKey";
+
+                var container = diBuilder()
+                    .bindFactory(
+                        typeKey,
+                        (r, { current }) => {
+                            return { scopeId: current, child: r.get("child") };
+                        },
+                        {
+                            lifecycle: "scope",
+                            withScope: true,
+                        },
+                    )
+                    .bindFactory("child", (_, { current }) => current, {
+                        lifecycle: "transient",
+                    })
+                    .build();
+
+                // Act ----------
+                var inst = container.get(typeKey);
+
+                var scope = container.scope(typeKey);
+                var instFromScope = scope.get(typeKey);
+
+                // Assert -------
+                expect(inst.scopeId).toBe(typeKey);
+                expect(inst.scopeId).toBe(scope.id);
+                expect(inst.child).toBe(scope.id);
+                expect(scope.isolated).is.false;
+                expect(scope.sealed).is.false;
+                expect(inst).toBe(instFromScope);
+            });
+
+            test("WHEN: Create isolated scope via factory binding", () => {
+                // Arrange ------
+                var typeKey = "typeKey";
+
+                var container = diBuilder()
+                    .bindFactory(
+                        typeKey,
+                        (r, { current }) => {
+                            return { scopeId: current, child: r.get("child") };
+                        },
+                        {
+                            lifecycle: "scope",
+                            withScope: { isolated: true },
+                        },
+                    )
+                    .bindFactory("child", (_, { current }) => current, {
+                        lifecycle: "transient",
+                    })
+                    .build();
+
+                // Act ----------
+                var inst = container.get(typeKey);
+
+                var scope = container.scope(typeKey);
+                var instFromScope = scope.get(typeKey);
+
+                // Assert -------
+                expect(inst.scopeId).toBe(typeKey);
+                expect(inst.scopeId).toBe(scope.id);
+                expect(inst.child).toBe(scope.id);
+                expect(scope.isolated).is.true;
+                expect(scope.sealed).is.false;
+                expect(inst).toBe(instFromScope);
             });
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,6 +537,14 @@
     "@jridgewell/sourcemap-codec" "^1.5.0"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@jridgewell/remapping@^2.3.4":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
@@ -550,7 +558,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
 
-"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
@@ -897,7 +905,35 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
-"@testing-library/dom@10.4.1":
+"@spirex/js-boot@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@spirex/js-boot/-/js-boot-1.1.1.tgz#5a3c2e3160ca0cb5ebb201e4647d07dc337b929e"
+  integrity sha512-4sv/GJ1P/cSFRyOHOjtlwWRNnrNh637emHWxuUgdUw+aDWuWDtlD8DC2tcvL6p/A9m0+1aaWroEZSeuQVFKYbw==
+
+"@sveltejs/acorn-typescript@^1.0.5":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.6.tgz#ca236a97d895869138091c6fba100114951daa97"
+  integrity sha512-4awhxtMh4cx9blePWl10HRHj8Iivtqj+2QdDCSMDzxG+XKa9+VCNupQuCuvzEhYPzZSrX+0gC+0lHA/0fFKKQQ==
+
+"@sveltejs/vite-plugin-svelte-inspector@^5.0.0":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-5.0.1.tgz#3d35254b76e07551ea8921029a96d99b94ffbc5c"
+  integrity sha512-ubWshlMk4bc8mkwWbg6vNvCeT7lGQojE3ijDh3QTR6Zr/R+GXxsGbyH4PExEPpiFmqPhYiVSVmHBjUcVc1JIrA==
+  dependencies:
+    debug "^4.4.1"
+
+"@sveltejs/vite-plugin-svelte@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.1.tgz#3414c10aaacce8f23a8db2a37926da00ab7a78cb"
+  integrity sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==
+  dependencies:
+    "@sveltejs/vite-plugin-svelte-inspector" "^5.0.0"
+    debug "^4.4.1"
+    deepmerge "^4.3.1"
+    magic-string "^0.30.17"
+    vitefu "^1.1.1"
+
+"@testing-library/dom@10.4.1", "@testing-library/dom@9.x.x || 10.x.x":
   version "10.4.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
   integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
@@ -918,6 +954,13 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@testing-library/svelte@5.2.8":
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/@testing-library/svelte/-/svelte-5.2.8.tgz#c9bae6da9cb436327b4a72971753d13b9da1dfcb"
+  integrity sha512-ucQOtGsJhtawOEtUmbR4rRh53e6RbM1KUluJIXRmh6D4UzxR847iIqqjRtg9mHNFmGQ8Vkam9yVcR5d1mhIHKA==
+  dependencies:
+    "@testing-library/dom" "9.x.x || 10.x.x"
+
 "@types/aria-query@^5.0.1":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
@@ -937,6 +980,11 @@
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
+
+"@types/estree@^1.0.5":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
+  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
 "@types/fs-extra@^8.0.1":
   version "8.1.5"
@@ -1099,7 +1147,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.14.0:
+acorn@^8.12.1, acorn@^8.14.0:
   version "8.15.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -1163,6 +1211,11 @@ aria-query@5.3.0:
   dependencies:
     dequal "^2.0.3"
 
+aria-query@^5.3.1:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
+  integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
@@ -1172,6 +1225,11 @@ assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+axobject-query@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
+  integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1259,6 +1317,11 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -1330,6 +1393,13 @@ debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.4.0:
   dependencies:
     ms "^2.1.3"
 
+debug@^4.4.1:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 decimal.js@^10.5.0:
   version "10.6.0"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
@@ -1345,7 +1415,7 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.2.2:
+deepmerge@^4.2.2, deepmerge@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
@@ -1555,6 +1625,11 @@ eslint@9.25.1:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
+esm-env@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/esm-env/-/esm-env-1.2.2.tgz#263c9455c55861f41618df31b20cb571fc20b75e"
+  integrity sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==
+
 espree@^10.0.1, espree@^10.3.0:
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-10.3.0.tgz#29267cf5b0cb98735b65e64ba07e0ed49d1eed8a"
@@ -1570,6 +1645,13 @@ esquery@^1.5.0:
   integrity sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==
   dependencies:
     estraverse "^5.1.0"
+
+esrap@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/esrap/-/esrap-2.1.2.tgz#7dcdec9d4157054dcd3e7a2b515a4664a5c4783d"
+  integrity sha512-DgvlIQeowRNyvLPWW4PT7Gu13WznY288Du086E751mwwbsgr29ytBiYeLzAGIo0qk3Ujob0SDk8TiSaM5WQzNg==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
 
 esrecurse@^4.3.0:
   version "4.3.0"
@@ -1927,6 +2009,13 @@ is-potential-custom-element-name@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
+is-reference@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-3.0.3.tgz#9ef7bf9029c70a67b2152da4adf57c23d718910f"
+  integrity sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==
+  dependencies:
+    "@types/estree" "^1.0.6"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -2136,6 +2225,11 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+locate-character@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-3.0.0.tgz#0305c5b8744f61028ef5d01f444009e00779f974"
+  integrity sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==
+
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
@@ -2174,6 +2268,13 @@ lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
+magic-string@^0.30.11:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 magic-string@^0.30.17:
   version "0.30.17"
@@ -2760,6 +2861,26 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+svelte@5.39.11:
+  version "5.39.11"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-5.39.11.tgz#e04cc3de508ff1be13e808f67a253a1ec3164ab1"
+  integrity sha512-8MxWVm2+3YwrFbPaxOlT1bbMi6OTenrAgks6soZfiaS8Fptk4EVyRIFhJc3RpO264EeSNwgjWAdki0ufg4zkGw==
+  dependencies:
+    "@jridgewell/remapping" "^2.3.4"
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@sveltejs/acorn-typescript" "^1.0.5"
+    "@types/estree" "^1.0.5"
+    acorn "^8.12.1"
+    aria-query "^5.3.1"
+    axobject-query "^4.1.0"
+    clsx "^2.1.1"
+    esm-env "^1.2.1"
+    esrap "^2.1.0"
+    is-reference "^3.0.3"
+    locate-character "^3.0.0"
+    magic-string "^0.30.11"
+    zimmerframe "^1.1.2"
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -2907,6 +3028,11 @@ vite-node@3.1.2:
   optionalDependencies:
     fsevents "~2.3.3"
 
+vitefu@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vitefu/-/vitefu-1.1.1.tgz#c39b7e4c91bf2f6c590fb96e0758f394dff5795b"
+  integrity sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==
+
 vitest@*, vitest@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.1.2.tgz#63afc16b6da3bea6e39f5387d80719e70634ba66"
@@ -3033,3 +3159,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zimmerframe@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/zimmerframe/-/zimmerframe-1.1.4.tgz#0352b5cafad3ad4526b0a526a9a52d9c040d865b"
+  integrity sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==


### PR DESCRIPTION
# SpireX/DI — v1.1.0 Change Log

Version 1.1.0 introduces a set of improvements aimed at making dependency management more flexible, type-safe, and observable.
The update expands the Middleware API, enhances builder introspection, strengthens factoryOf, and improves scoped bindings and metadata typing.

Together, these changes make **SpireX/DI** easier to extend and safer to use in large or highly modular applications.

## Middleware Enhancements

### `onPreBuild` Hook
A new `onPreBuild` hook is executed **before container build starts**.
It allows middleware to validate builder state, inspect existing bindings, or register additional bindings required for middleware operation.

This hook is especially useful for enforcing constraints or preparing internal services before the container is finalized.

```js
builder.use({
    onPreBuild(builder) {
        builder.findEntry(entry => entry.type === 'config');
        builder.bindInstance('internalLogger', loggerInstance);
        builder.hasModule('core');
    },
});
```

### `onPostBuild` Hook
The new `onPostBuild` hook runs after the container has been successfully built and all singletons are activated.

It enables final verification and eager configuration of services before the container is exposed to the application.

```js
builder.use({
    onPostBuild(container) {
        container.maybe('service');
        container.scope('ui').get('sharedStore');
        container.get('logger').time('di-ready');
    },
});
```
This hook is ideal for health checks, warm-up logic, or instrumentation.

### Builder Access in `onBind`
The `onBind` hook now receives a reference to the **current builder**.

This allows bindings to react dynamically to other bindings, enabling advanced patterns such as grouping, aliasing, or conditional registration.

```js
builder.use({
    onBind(entry, origin, builder) {
        if (entry.type === 'cmdHandler' && entry.name) {
            builder.bindAlias('cmdHandler', entry.type, {
                originName: entry.name,
                ifConflict: 'append',
            });
        }
        return entry;
    },
});
```

### Activation Stack in `onActivated`
The `onActivated` hook now provides an **activation stack**, showing the full dependency chain that caused an instance to be created.

This makes it possible to understand who requested a dependency and why it was activated.

```js
builder.use({
    onActivated(entry, instance, scope, stack) {
        // Example stack:
        // ['viewModel', 'interceptor', 'repo', 'http']
        // The current type is the last element.
        // The initiator of activation is the first element.
    },
});
```
This feature enables advanced diagnostics, conditional decoration, and tracing.

### Typed Middleware with `TypeMap`
Middleware can now define its own `TypeMap` and **inherit** the container’s `TypeMap`.

This allows middleware to:
- Register new types without splitting logic into a module;
- Access container types with full TypeScript type checking;
- Use `onUse` and `onPreBuild` hooks with strong typing.


```ts
diBuilder<{ service: MyService }>().use({
    onUse(builder) {
        // builder:
        // IContainerBuilder<{ service: MyService }>
        builder.findEntry('service') 
    }
})
```
This significantly improves middleware authoring ergonomics and safety.


## Scoped Factory Bindings
Factory bindings can now be declared as their **own scope** using `withScope` option.

When enabled, a new scope is created **per type key**, and both the instance and its dependencies are resolved within that scope.

```ts
builder.bindFactory(
    'typeKey',
    factoryOf(MyService),
    { withScope: true },
);
```
This is useful for isolating stateful services or implementing per-feature lifetimes.

## Strongly Typed Binding Metadata

### Typed Metadata Dictionary
Binding metadata is now described using the generic type
`TTypeEntryMeta<TypeMap, TypeKey>` with values of `ITypeEntryMetaData<TypeMap, TypeKey>`.

Metadata can now:
- Reference other container types safely;
- Access the current type key;
- Fail at compile time if referenced types are renamed or missing.

```ts
function spy<TypeMap extends TTypeMapBase, T>(
    logger: keyof TypeMapFilterByType<TypeMap, ILogger>,
): ITypeEntryMeta<TypeMap, T> {
    return {
        spy: { logger },
    };
}

builder.bindFactory('service', factoryOf(MyService), {
    meta: spy('appLogger'),
});
```
This enables metadata-driven tooling while preserving full type safety.


## Builder Inspection and Entry Search

### `find` and `findAll` Methods
The builder now provides `find` and `findAll` methods for searching type bindings using a predicate.

- `find` returns the first matching entry
- `findAll` returns all matching entries

These methods are available:
- On the builder itself
- Inside middleware hooks: `onUse`, `onBind`, `onPreBuild`

```js
builder.find(entry => entry.meta?.spy !== undefined);
builder.findAll(entry => entry.scope === 'ui');
```

## `factoryOf` Improvements

### Frozen Class Dependencies
Class dependency lists captured by `factoryOf` are now **frozen at registration time**.

This prevents accidental or malicious runtime modification of constructor dependency metadata after factory registration.

### `factoryOf` for Factory Functions
`factoryOf` now supports **plain factory functions**, reducing boilerplate for manual dependency extraction.

```js
builder.bindFactory(
    'service',
    factoryOf(
        makeService,
        ['user', 'eventBus', 'repo', 'logger'],
    ),
);

// Equivalent to:
builder.bindFactory('service', r =>
    makeService(
        r.get('user'),
        r.get('eventBus'),
        r.get('repo'),
        r.get('logger'),
    ),
);
```

### Fast-Fail Dependency Validation
Because `factoryOf` knows all dependency keys in advance, they are now **validated during container build**.

If a required dependency is missing, container construction fails immediately—similar to `bindSafeFactory`.

```ts
const container = diBuilder<{
    auth: AuthService;
    authGateway: IAuthGateway;
}>()
    .bindFactory('auth', factoryOf(AuthService))
    .build(); // Throws: 'authGateway' is not bound
```
This provides safer defaults without sacrificing performance.

## Falsy Branch Support in `when`
The `when` operator now supports an optional **falsy branch**, removing the need to define two separate conditions.
```ts
builder.when(
    condition,
    (binder) => { /* truthy branch */ },
    (binder) => { /* falsy branch */ },
);
```
This simplifies conditional binding logic and improves readability.

----------------
## Summary

**SpireX/DI v1.1.0** significantly enhances middleware extensibility, lifecycle visibility, and type safety.
Developers gain new lifecycle hooks, better diagnostics through activation stacks, and more powerful builder analysis tools.

`factoryOf` becomes safer and more expressive, while typed metadata and scoped bindings unlock advanced architectural patterns.

Overall, this release makes dependency management more predictable, observable, and maintainable in complex applications.
